### PR TITLE
fix: rename endKeyUp to endKeyDown

### DIFF
--- a/src/keyboard.ts
+++ b/src/keyboard.ts
@@ -139,7 +139,7 @@ export function homeKeyDown(target: Element, modifiers: string | string[] = []):
   keyDownOn(target, 36, modifiers, 'Home');
 }
 
-export function endKeyUp(target: Element, modifiers: string | string[] = []): void {
+export function endKeyDown(target: Element, modifiers: string | string[] = []): void {
   keyDownOn(target, 35, modifiers, 'End');
 }
 


### PR DESCRIPTION
ATM, the `endKeyUp` function works as if it is an `endKeyDown` function that is quite unexpected behavior:

```ts
export function endKeyUp/* <------ */(target: Element, modifiers: string | string[] = []): void {
  keyDownOn/* <------ */(target, 35, modifiers, 'End');
}
```

So I've renamed `endKeyUp` to `endKeyDown` to get the naming aligned to the function's actual behavior.