### PR TITLE
fix: set event props for focusin, focusout events

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -32,7 +32,7 @@ export function tap(node: Node): CustomEvent {
  */
 export function focusin(node: Node, relatedTarget?: Node): CustomEvent {
   const eventProps = relatedTarget ? { relatedTarget } : {};
-  return fire(node, 'focusin', eventProps);
+  return fire(node, 'focusin', undefined, eventProps);
 }
 
 /**
@@ -40,5 +40,5 @@ export function focusin(node: Node, relatedTarget?: Node): CustomEvent {
  */
 export function focusout(node: Node, relatedTarget?: Node): CustomEvent {
   const eventProps = relatedTarget ? { relatedTarget } : {};
-  return fire(node, 'focusout', eventProps);
+  return fire(node, 'focusout', undefined, eventProps);
 }


### PR DESCRIPTION
ATM, the `relatedTarget` property for the `focusin`, `focusout` event helpers falls into the event details, though it should be set as a property of the event class.

This PR is intended to fix this behaviour.