### PR TITLE
refactor!: remove Polymer from helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@polymer/polymer": "^3.5.1",
     "lit": "^3.0.0"
   },
   "devDependencies": {

--- a/src/define.ts
+++ b/src/define.ts
@@ -1,25 +1,8 @@
-import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { html, LitElement } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import type { Constructor } from './utils.js';
 
 declare type ClassFactory = <T extends Constructor<HTMLElement>>(_base: T) => T;
-
-export const definePolymer = (prefix: string, htmlString: string, classFactory: ClassFactory): string => {
-  const tag = `${prefix}-polymer-element`;
-
-  class Base extends classFactory(PolymerElement) {
-    static get template() {
-      const tpl = document.createElement('template');
-      tpl.innerHTML = htmlString;
-      return tpl;
-    }
-  }
-
-  customElements.define(tag, Base);
-
-  return tag;
-};
 
 export const defineLit = (prefix: string, htmlString: string, classFactory: ClassFactory): string => {
   const tag = `${prefix}-lit-element`;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,3 @@
-import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
-
 let defineCECounter = 0;
 
 export type Constructor<T> = new (..._args: any[]) => T; // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -58,14 +56,15 @@ export async function nextFrame(): Promise<void> {
 }
 
 /**
- * Resolves after afterNextRender Polymer hook.
+ * Resolves after the next render, by runing after one task (`setTimout`)
+ * after the next `requestAnimationFrame`
  *
  * @return {Promise<void>} Promise resolved after next render
  */
-export async function nextRender(target: Node): Promise<void> {
+export async function nextRender(): Promise<void> {
   return new Promise((resolve) => {
-    afterNextRender(target, () => {
-      resolve();
+    requestAnimationFrame(() => {
+      setTimeout(() => resolve());
     });
   });
 }


### PR DESCRIPTION
## Description

Remove dependency the from Polymer from the `testing-helpers` library. Also, change the `nextRender` API to remove the `target` parameter as it wasn't being used as intended by the `afterNextRender` function.